### PR TITLE
feat: allow prettier packages as dependency if keywords include `"pre…

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,35 @@ If your `package.json` contains the `"eslint"` keyword the ESLint packages can b
 }
 ```
 
+### Prettier
+
+If your `package.json` contains the `"prettier"` keyword the Prettier packages can be included as dependencies, e.g. if you publish a sharable config including a plugin you must include `"prettier"` as a keyword.
+
+**OK**:
+
+```json
+{
+  "name": "prettier-config-myfancyconfig",
+  "version": "1.0.0",
+  "keywords": ["prettier"],
+  "dependencies": {
+    "prettier-plugin-myfancyplugin": "^1.2.0"
+  }
+}
+```
+
+**Fail**:
+
+```json
+{
+  "name": "prettier-config-myfancyconfig",
+  "version": "1.0.0",
+  "dependencies": {
+    "prettier-plugin-myfancyplugin": "^1.2.0"
+  }
+}
+```
+
 ## Shebang
 
 Require all binaries to have UNIX-style shebang at the beginning of the file.

--- a/src/rules/disallowed-dependency.spec.ts
+++ b/src/rules/disallowed-dependency.spec.ts
@@ -41,7 +41,10 @@ describe("package list", () => {
 		"jest",
 		"mocha",
 		"prettier",
+		"prettier-config-foobar",
 		"prettier-plugin-foobar",
+		"@scope/prettier-config-foobar",
+		"@scope/prettier-plugin-foobar",
 		"ts-node",
 		"typescript",
 		"webpack",
@@ -71,4 +74,17 @@ it("should allow eslint-* if package keywords includes eslint", () => {
 	expect(isDisallowedDependency(eslintPkg, "@scope/eslint-config-foobar")).toBeFalsy();
 	expect(isDisallowedDependency(eslintPkg, "@scope/eslint-formatter-foobar")).toBeFalsy();
 	expect(isDisallowedDependency(eslintPkg, "@scope/eslint-plugin-foobar")).toBeFalsy();
+});
+
+it("should allow prettier-* if package keywords includes prettier", () => {
+	expect.assertions(5);
+	const eslintPkg: PackageJson = {
+		...pkg,
+		keywords: ["prettier"],
+	};
+	expect(isDisallowedDependency(eslintPkg, "prettier")).toBeFalsy();
+	expect(isDisallowedDependency(eslintPkg, "prettier-config-foobar")).toBeFalsy();
+	expect(isDisallowedDependency(eslintPkg, "prettier-plugin-foobar")).toBeFalsy();
+	expect(isDisallowedDependency(eslintPkg, "@scope/prettier-config-foobar")).toBeFalsy();
+	expect(isDisallowedDependency(eslintPkg, "@scope/prettier-plugin-foobar")).toBeFalsy();
 });

--- a/src/rules/disallowed-dependency.ts
+++ b/src/rules/disallowed-dependency.ts
@@ -28,7 +28,6 @@ const disallowedDependencies: RegExp[] = [
 	prefix("jest"),
 	prefix("mocha"),
 	prefix("nyc"),
-	prefix("prettier"),
 	prefix("protractor"),
 	prefix("ts-node"),
 	prefix("typescript"),
@@ -45,6 +44,12 @@ const disallowedEslint: RegExp[] = [
 	scopedPrefix("eslint-config"),
 	scopedPrefix("eslint-formatter"),
 	scopedPrefix("eslint-plugin"),
+];
+
+const disallowedPrettier: RegExp[] = [
+	exact("prettier"),
+	prefix("prettier-"),
+	scopedPrefix("prettier-"),
 ];
 
 const allowedDependencies: string[] = [
@@ -66,9 +71,15 @@ export function isDisallowedDependency(pkg: PackageJson, dependency: string): bo
 		return false;
 	}
 
-	/* eslint-* is allowed only if keywords includes "eslint" */
 	const keywords = pkg.keywords || [];
+
+	/* eslint-* is allowed only if keywords includes "eslint" */
 	if (!keywords.includes("eslint") && match(disallowedEslint, dependency)) {
+		return true;
+	}
+
+	/* prettier-* is allowed only if keywords includes "prettier" */
+	if (!keywords.includes("prettier") && match(disallowedPrettier, dependency)) {
 		return true;
 	}
 


### PR DESCRIPTION
…ttier"`