### PR TITLE
feat: new rule `shadowed-types`

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ Requires `types` to be the first condition in `exports`.
 
 **Why?** For TypeScript to properly detect `types` it need to come before `require` or `import`, else it will fall back to detecting by filename.
 
+## TypeScript `types` matching `exports`
+
+Requires `types` to match `exports`.
+
+**Why?** To avoid issues with newer TS versions resolving with `exports` if present rather than the older `types` field.
+
 ## Disallowed dependencies
 
 Disallows certain packages from being included as `dependencies` (use `devDependencies` or `peerDependencies` instead).

--- a/src/package-json.ts
+++ b/src/package-json.ts
@@ -6,6 +6,7 @@ import { isDisallowedDependency } from "./rules/disallowed-dependency";
 import { exportsTypesOrder } from "./rules/exports-types-order";
 import { isObsoleteDependency } from "./rules/obsolete-dependency";
 import { outdatedEngines } from "./rules/outdated-engines";
+import { shadowedTypes } from "./rules/shadowed-types";
 import { typesNodeMatchingEngine } from "./rules/types-node-matching-engine";
 import { verifyEngineConstraint } from "./rules/verify-engine-constraint";
 import { type PackageJson } from "./types";
@@ -170,6 +171,7 @@ export async function verifyPackageJson(
 		...verifyFields(pkg, pkgAst, options),
 		...verifyDependencies(pkg, pkgAst, options),
 		...outdatedEngines(pkg, pkgAst, ignoreNodeVersion),
+		...shadowedTypes(pkg, pkgAst),
 		...typesNodeMatchingEngine(pkg, pkgAst),
 	];
 

--- a/src/rules/shadowed-types.spec.ts
+++ b/src/rules/shadowed-types.spec.ts
@@ -1,0 +1,153 @@
+/* eslint-disable jest/no-interpolation-in-snapshots -- easier to test both fields this way */
+
+import { type DocumentNode, parse } from "@humanwhocodes/momoa";
+import { type PackageJson } from "../types";
+import { codeframe } from "../utils/codeframe";
+import { shadowedTypes } from "./shadowed-types";
+
+function generateAst(pkg: PackageJson): { content: string; ast: DocumentNode } {
+	const content = JSON.stringify(pkg, null, 2);
+	return { content, ast: parse(content) };
+}
+
+describe.each(["types", "typings"])("%s", (field) => {
+	it(`should not allow ${field} field to be shadowed by exports with types condition`, () => {
+		expect.assertions(1);
+		const pkg: PackageJson = {
+			name: "mock-package",
+			version: "1.2.3",
+			exports: {
+				".": {
+					types: "./dist/foo.d.ts",
+					default: "./dist/foo.js",
+				},
+			},
+			[field]: "./foo.d.ts",
+		};
+		const { content, ast } = generateAst(pkg);
+		expect(codeframe(content, shadowedTypes(pkg, ast))).toMatchInlineSnapshot(`
+			"ERROR: "${field}" cannot be resolved when respecting "exports" field (shadowed-types) at package.json
+			   8 |     }
+			   9 |   },
+			> 10 |   "${field}": "./foo.d.ts"
+			     |   ^
+			  11 | }"
+		`);
+	});
+
+	it(`should not allow ${field} field to be shadowed by exports without types condition`, () => {
+		expect.assertions(1);
+		const pkg: PackageJson = {
+			name: "mock-package",
+			version: "1.2.3",
+			exports: {
+				".": {
+					default: "./dist/foo.js",
+				},
+			},
+			[field]: "./foo.d.ts",
+		};
+		const { content, ast } = generateAst(pkg);
+		expect(codeframe(content, shadowedTypes(pkg, ast))).toMatchInlineSnapshot(`
+			"ERROR: "${field}" cannot be resolved when respecting "exports" field (shadowed-types) at package.json
+			   7 |     }
+			   8 |   },
+			>  9 |   "${field}": "./foo.d.ts"
+			     |   ^
+			  10 | }"
+		`);
+	});
+
+	it(`should not allow ${field} field to be shadowed by exports subpath string`, () => {
+		expect.assertions(1);
+		const pkg: PackageJson = {
+			name: "mock-package",
+			version: "1.2.3",
+			exports: {
+				".": "./dist/foo.js",
+			},
+			[field]: "./foo.d.ts",
+		};
+		const { content, ast } = generateAst(pkg);
+		expect(codeframe(content, shadowedTypes(pkg, ast))).toMatchInlineSnapshot(`
+			"ERROR: "${field}" cannot be resolved when respecting "exports" field (shadowed-types) at package.json
+			  5 |     ".": "./dist/foo.js"
+			  6 |   },
+			> 7 |   "${field}": "./foo.d.ts"
+			    |   ^
+			  8 | }"
+		`);
+	});
+
+	it(`should not allow ${field} field to be shadowed by exports string`, () => {
+		expect.assertions(1);
+		const pkg: PackageJson = {
+			name: "mock-package",
+			version: "1.2.3",
+			exports: "./dist/foo.js",
+			[field]: "./foo.d.ts",
+		};
+		const { content, ast } = generateAst(pkg);
+		expect(codeframe(content, shadowedTypes(pkg, ast))).toMatchInlineSnapshot(`
+			"ERROR: "${field}" cannot be resolved when respecting "exports" field (shadowed-types) at package.json
+			  3 |   "version": "1.2.3",
+			  4 |   "exports": "./dist/foo.js",
+			> 5 |   "${field}": "./foo.d.ts"
+			    |   ^
+			  6 | }"
+		`);
+	});
+
+	it(`should allow ${field} field when matching exports (with dot slash)`, () => {
+		expect.assertions(1);
+		const pkg: PackageJson = {
+			name: "mock-package",
+			version: "1.2.3",
+			exports: {
+				".": {
+					types: "./dist/foo.d.ts",
+				},
+			},
+			[field]: "./dist/foo.d.ts",
+		};
+		const { content, ast } = generateAst(pkg);
+		expect(codeframe(content, shadowedTypes(pkg, ast))).toMatchInlineSnapshot(`""`);
+	});
+
+	it(`should allow ${field} field when matching exports (without dot slash)`, () => {
+		expect.assertions(1);
+		const pkg: PackageJson = {
+			name: "mock-package",
+			version: "1.2.3",
+			exports: {
+				".": {
+					types: "./dist/foo.d.ts",
+				},
+			},
+			[field]: "dist/foo.d.ts",
+		};
+		const { content, ast } = generateAst(pkg);
+		expect(codeframe(content, shadowedTypes(pkg, ast))).toMatchInlineSnapshot(`""`);
+	});
+
+	it(`should handle when exports is missing`, () => {
+		expect.assertions(1);
+		const pkg: PackageJson = {
+			name: "mock-package",
+			version: "1.2.3",
+			[field]: "dist/foo.d.ts",
+		};
+		const { content, ast } = generateAst(pkg);
+		expect(codeframe(content, shadowedTypes(pkg, ast))).toMatchInlineSnapshot(`""`);
+	});
+
+	it(`should handle when ${field} is missing`, () => {
+		expect.assertions(1);
+		const pkg: PackageJson = {
+			name: "mock-package",
+			version: "1.2.3",
+		};
+		const { content, ast } = generateAst(pkg);
+		expect(codeframe(content, shadowedTypes(pkg, ast))).toMatchInlineSnapshot(`""`);
+	});
+});

--- a/src/rules/shadowed-types.ts
+++ b/src/rules/shadowed-types.ts
@@ -1,0 +1,83 @@
+import { Severity } from "@html-validate/stylish";
+import { type DocumentNode } from "@humanwhocodes/momoa";
+import { type Message } from "../message";
+import { type PackageJson, type PackageJsonExports } from "../types";
+import { jsonLocation } from "../utils";
+
+const ruleId = "shadowed-types";
+const severity = Severity.ERROR;
+
+function findDotTypes(exports: string | PackageJsonExports): string | null {
+	if (typeof exports === "string") {
+		return null;
+	}
+	const dot = exports["."];
+	if (!dot || typeof dot === "string") {
+		return null;
+	}
+	const types = dot.types;
+	if (typeof types === "string") {
+		return types;
+	} else {
+		return null;
+	}
+}
+
+/**
+ * Compare "types" from "exports" with the "types" or "typings" field and yields
+ * an error if there is a mismatch.
+ *
+ * @param pkgAst - JSON syntax tree to get error location from.
+ * @param subpath - The resolved value from exports ".".
+ * @param field - Which field holds the value parameter.
+ * @param value - The value of the "types" or "typings" field.
+ */
+function* validateTypeSubpath(
+	pkgAst: DocumentNode,
+	subpath: string | null,
+	field: "types" | "typings",
+	value: string,
+): Generator<Message> {
+	/* `{types: "dist/foo.d.ts"}` - compare directly with subpath (which always contains the `./` prefix) */
+	if (value.startsWith("./") && subpath === value) {
+		return;
+	}
+
+	/* `{types: "dist/foo.d.ts"}` - add `./` prefix before comparison */
+	if (subpath === `./${value}`) {
+		return;
+	}
+
+	const { line, column } = jsonLocation(pkgAst, "member", field);
+	yield {
+		ruleId,
+		severity,
+		message: `"${field}" cannot be resolved when respecting "exports" field`,
+		line,
+		column,
+	};
+}
+
+/**
+ * Validates the `"types"` or `"typings"` field against the `"exports"` field to
+ * ensure all versions of TypeScript can resolve the types.
+ *
+ * @param pkg - Parsed `package.json"`.
+ * @param pkgAst - JSON syntax tree for the `pkg` parameter.
+ */
+export function* shadowedTypes(pkg: PackageJson, pkgAst: DocumentNode): Generator<Message> {
+	const { exports } = pkg;
+	if (!exports) {
+		return;
+	}
+
+	const subpath = findDotTypes(exports);
+
+	if (pkg.types) {
+		yield* validateTypeSubpath(pkgAst, subpath, "types", pkg.types);
+	}
+
+	if (pkg.typings) {
+		yield* validateTypeSubpath(pkgAst, subpath, "typings", pkg.typings);
+	}
+}

--- a/src/types/package-json.ts
+++ b/src/types/package-json.ts
@@ -33,6 +33,7 @@ export interface PackageJson {
 	module?: string;
 	"jsnext:main"?: string;
 	exports?: string | null | PackageJsonExports;
+	types?: string;
 	typings?: string;
 	bin?: string | Record<string, string>;
 	man?: string | string[];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a validation rule to detect when TypeScript type declaration fields (types/typings) are shadowed or misaligned by package "exports".

* **Documentation**
  * Added guidance on aligning the `types` field with `exports` to avoid resolution issues with newer TypeScript versions.

* **Tests**
  * Added comprehensive test coverage for the new validation rule across varied export scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->