### PR TITLE
fix: validate pkg.types in addition to pkg.typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Verifies the presence of files specified in:
 - `browser`
 - `module`
 - `jsnext:main`,
+- `types`
 - `typings`
 - `bin`
 - `man`

--- a/src/__snapshots__/tarball.spec.ts.snap
+++ b/src/__snapshots__/tarball.spec.ts.snap
@@ -172,6 +172,18 @@ exports[`should return error if package.json references missing file module 1`] 
 ]
 `;
 
+exports[`should return error if package.json references missing file types 1`] = `
+[
+  {
+    "column": 1,
+    "line": 1,
+    "message": "index.d.ts (pkg.types) is not present in tarball",
+    "ruleId": "no-missing-types",
+    "severity": 2,
+  },
+]
+`;
+
 exports[`should return error if package.json references missing file typings 1`] = `
 [
   {

--- a/src/tarball.spec.ts
+++ b/src/tarball.spec.ts
@@ -54,6 +54,7 @@ describe("should return error if package.json references missing file", () => {
 		${"browser"}             | ${{ browser: "index.js" }}
 		${"module"}              | ${{ module: "index.js" }}
 		${"jsnext:main"}         | ${{ "jsnext:main": "index.js" }}
+		${"types"}               | ${{ types: "index.d.ts" }}
 		${"typings"}             | ${{ typings: "index.d.ts" }}
 		${"bin (single)"}        | ${{ bin: "index.js" }}
 		${"bin (multiple)"}      | ${{ bin: { foo: "dist/foo.js", bar: "dist/bar.js" } }}
@@ -85,6 +86,7 @@ describe("should not return error if package.json references existing file", () 
 		${"browser"}             | ${{ browser: "index.js" }}
 		${"module"}              | ${{ module: "index.js" }}
 		${"jsnext:main"}         | ${{ "jsnext:main": "index.js" }}
+		${"types"}               | ${{ types: "index.d.ts" }}
 		${"typings"}             | ${{ typings: "index.d.ts" }}
 		${"bin (single)"}        | ${{ bin: "index.js" }}
 		${"bin (multiple)"}      | ${{ bin: { foo: "dist/foo.js", bar: "dist/bar.js" } }}

--- a/src/tarball.ts
+++ b/src/tarball.ts
@@ -138,6 +138,9 @@ function* requiredFiles(pkg: PackageJson): Generator<RequiredFile> {
 			ruleId,
 		});
 	}
+	if (pkg.types) {
+		yield* yieldRequiredFiles(pkg.types, { field: "types", ruleId: "no-missing-types" });
+	}
 	if (pkg.typings) {
 		yield* yieldRequiredFiles(pkg.typings, { field: "typings", ruleId: "no-missing-typings" });
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for validating the `types` field in package configuration, extending validation coverage to match existing field handling.

* **Documentation**
  * Updated the missing files verification checklist to include the `types` entry alongside existing field entries.

* **Tests**
  * Expanded test coverage to validate the `types` field in both missing file and existing file scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->