### PR TITLE
Prefer `types` over `typings`

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ Requires `types` to be used instead of `typings`.
 
 **Why?** While TypeScript allows `typings` to be used as an alias, it is better for consistency to only use one over the other.
 
+## TypeScript conflicting `types` and `typings` fields
+
+Requires only one of the two fields `types` and `typings` to be used, not both.
+
+**Why?** `typings` is an alias for `types` and if both are set it is unclear which is to be used (and could potentially be set to different values).
+
 ## Disallowed dependencies
 
 Disallows certain packages from being included as `dependencies` (use `devDependencies` or `peerDependencies` instead).

--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ Requires `types` to match `exports`.
 
 **Why?** To avoid issues with newer TS versions resolving with `exports` if present rather than the older `types` field.
 
+## TypeScript prefer `types` over `typings`
+
+Requires `types` to be used instead of `typings`.
+
+**Why?** While TypeScript allows `typings` to be used as an alias, it is better for consistency to only use one over the other.
+
 ## Disallowed dependencies
 
 Disallows certain packages from being included as `dependencies` (use `devDependencies` or `peerDependencies` instead).

--- a/src/package-json.ts
+++ b/src/package-json.ts
@@ -1,6 +1,7 @@
 import { type DocumentNode } from "@humanwhocodes/momoa";
 import { type Message } from "./message";
 import { type Result } from "./result";
+import { conflictingTypesTypings } from "./rules/conflicting-types-typings";
 import { deprecatedDependency } from "./rules/deprecated-dependency";
 import { isDisallowedDependency } from "./rules/disallowed-dependency";
 import { exportsTypesOrder } from "./rules/exports-types-order";
@@ -166,6 +167,7 @@ export async function verifyPackageJson(
 	const { ignoreNodeVersion } = options;
 
 	const messages: Message[] = [
+		...conflictingTypesTypings(pkg, pkgAst),
 		...(await deprecatedDependency(pkg, pkgAst, options)),
 		...(await verifyEngineConstraint(pkg)),
 		...exportsTypesOrder(pkg, pkgAst),

--- a/src/package-json.ts
+++ b/src/package-json.ts
@@ -6,6 +6,7 @@ import { isDisallowedDependency } from "./rules/disallowed-dependency";
 import { exportsTypesOrder } from "./rules/exports-types-order";
 import { isObsoleteDependency } from "./rules/obsolete-dependency";
 import { outdatedEngines } from "./rules/outdated-engines";
+import { preferTypes } from "./rules/prefer-types";
 import { shadowedTypes } from "./rules/shadowed-types";
 import { typesNodeMatchingEngine } from "./rules/types-node-matching-engine";
 import { verifyEngineConstraint } from "./rules/verify-engine-constraint";
@@ -171,6 +172,7 @@ export async function verifyPackageJson(
 		...verifyFields(pkg, pkgAst, options),
 		...verifyDependencies(pkg, pkgAst, options),
 		...outdatedEngines(pkg, pkgAst, ignoreNodeVersion),
+		...preferTypes(pkg, pkgAst),
 		...shadowedTypes(pkg, pkgAst),
 		...typesNodeMatchingEngine(pkg, pkgAst),
 	];

--- a/src/rules/conflicting-types-typings.spec.ts
+++ b/src/rules/conflicting-types-typings.spec.ts
@@ -1,0 +1,60 @@
+import { type DocumentNode, parse } from "@humanwhocodes/momoa";
+import { type PackageJson } from "../types";
+import { codeframe } from "../utils/codeframe";
+import { conflictingTypesTypings } from "./conflicting-types-typings";
+
+function generateAst(pkg: PackageJson): { content: string; ast: DocumentNode } {
+	const content = JSON.stringify(pkg, null, 2);
+	return { content, ast: parse(content) };
+}
+
+it(`should report error when both "types" and "typings" is used`, () => {
+	expect.assertions(1);
+	const pkg: PackageJson = {
+		name: "mock-package",
+		version: "1.2.3",
+		types: "./foo.d.ts",
+		typings: "./foo.d.ts",
+	};
+	const { content, ast } = generateAst(pkg);
+	expect(codeframe(content, conflictingTypesTypings(pkg, ast))).toMatchInlineSnapshot(`
+		"ERROR: Duplicate "typings" and "types" field (conflicting-types-typings) at package.json
+		  3 |   "version": "1.2.3",
+		  4 |   "types": "./foo.d.ts",
+		> 5 |   "typings": "./foo.d.ts"
+		    |   ^
+		  6 | }"
+	`);
+});
+
+it(`should not report when only "types" is set`, () => {
+	expect.assertions(1);
+	const pkg: PackageJson = {
+		name: "mock-package",
+		version: "1.2.3",
+		types: "index.d.ts",
+	};
+	const { content, ast } = generateAst(pkg);
+	expect(codeframe(content, conflictingTypesTypings(pkg, ast))).toMatchInlineSnapshot(`""`);
+});
+
+it(`should not report when only "typings" is set`, () => {
+	expect.assertions(1);
+	const pkg: PackageJson = {
+		name: "mock-package",
+		version: "1.2.3",
+		typings: "index.d.ts",
+	};
+	const { content, ast } = generateAst(pkg);
+	expect(codeframe(content, conflictingTypesTypings(pkg, ast))).toMatchInlineSnapshot(`""`);
+});
+
+it(`should not report when neither "types" or "typings" is set`, () => {
+	expect.assertions(1);
+	const pkg: PackageJson = {
+		name: "mock-package",
+		version: "1.2.3",
+	};
+	const { content, ast } = generateAst(pkg);
+	expect(codeframe(content, conflictingTypesTypings(pkg, ast))).toMatchInlineSnapshot(`""`);
+});

--- a/src/rules/conflicting-types-typings.ts
+++ b/src/rules/conflicting-types-typings.ts
@@ -1,0 +1,32 @@
+import { Severity } from "@html-validate/stylish";
+import { type DocumentNode } from "@humanwhocodes/momoa";
+import { type Message } from "../message";
+import { type PackageJson } from "../types";
+import { jsonLocation } from "../utils";
+
+const ruleId = "conflicting-types-typings";
+const severity = Severity.ERROR;
+
+/**
+ * Yields an error if both the `types` and `typings` field are set.
+ *
+ * @param pkg - Parsed `package.json"`.
+ * @param pkgAst - JSON syntax tree for the `pkg` parameter.
+ */
+export function* conflictingTypesTypings(
+	pkg: PackageJson,
+	pkgAst: DocumentNode,
+): Generator<Message> {
+	if (!pkg.types || !pkg.typings) {
+		return;
+	}
+
+	const { line, column } = jsonLocation(pkgAst, "member", "typings");
+	yield {
+		ruleId,
+		severity,
+		message: `Duplicate "typings" and "types" field`,
+		line,
+		column,
+	};
+}

--- a/src/rules/prefer-types.spec.ts
+++ b/src/rules/prefer-types.spec.ts
@@ -1,0 +1,60 @@
+import { type DocumentNode, parse } from "@humanwhocodes/momoa";
+import { type PackageJson } from "../types";
+import { codeframe } from "../utils/codeframe";
+import { preferTypes } from "./prefer-types";
+
+function generateAst(pkg: PackageJson): { content: string; ast: DocumentNode } {
+	const content = JSON.stringify(pkg, null, 2);
+	return { content, ast: parse(content) };
+}
+
+it(`should report error when "typings" is used instead of "types"`, () => {
+	expect.assertions(1);
+	const pkg: PackageJson = {
+		name: "mock-package",
+		version: "1.2.3",
+		typings: "./foo.d.ts",
+	};
+	const { content, ast } = generateAst(pkg);
+	expect(codeframe(content, preferTypes(pkg, ast))).toMatchInlineSnapshot(`
+		"ERROR: Prefer "types" over "typings" (prefer-types) at package.json
+		  2 |   "name": "mock-package",
+		  3 |   "version": "1.2.3",
+		> 4 |   "typings": "./foo.d.ts"
+		    |   ^
+		  5 | }"
+	`);
+});
+
+it(`should not report error when both "typings" and "types" are set`, () => {
+	expect.assertions(1);
+	const pkg: PackageJson = {
+		name: "mock-package",
+		version: "1.2.3",
+		types: "./foo.d.ts",
+		typings: "./foo.d.ts",
+	};
+	const { content, ast } = generateAst(pkg);
+	expect(codeframe(content, preferTypes(pkg, ast))).toMatchInlineSnapshot(`""`);
+});
+
+it(`should not report when only "types" is set`, () => {
+	expect.assertions(1);
+	const pkg: PackageJson = {
+		name: "mock-package",
+		version: "1.2.3",
+		types: "./foo.d.ts",
+	};
+	const { content, ast } = generateAst(pkg);
+	expect(codeframe(content, preferTypes(pkg, ast))).toMatchInlineSnapshot(`""`);
+});
+
+it(`should not report when neither "types" or "typings" is set`, () => {
+	expect.assertions(1);
+	const pkg: PackageJson = {
+		name: "mock-package",
+		version: "1.2.3",
+	};
+	const { content, ast } = generateAst(pkg);
+	expect(codeframe(content, preferTypes(pkg, ast))).toMatchInlineSnapshot(`""`);
+});

--- a/src/rules/prefer-types.ts
+++ b/src/rules/prefer-types.ts
@@ -1,0 +1,29 @@
+import { Severity } from "@html-validate/stylish";
+import { type DocumentNode } from "@humanwhocodes/momoa";
+import { type Message } from "../message";
+import { type PackageJson } from "../types";
+import { jsonLocation } from "../utils";
+
+const ruleId = "prefer-types";
+const severity = Severity.ERROR;
+
+/**
+ * Yields an error if the `typings` field is present instead of `types`.
+ *
+ * @param pkg - Parsed `package.json"`.
+ * @param pkgAst - JSON syntax tree for the `pkg` parameter.
+ */
+export function* preferTypes(pkg: PackageJson, pkgAst: DocumentNode): Generator<Message> {
+	if (!pkg.typings || pkg.types) {
+		return;
+	}
+
+	const { line, column } = jsonLocation(pkgAst, "member", "typings");
+	yield {
+		ruleId,
+		severity,
+		message: `Prefer "types" over "typings"`,
+		line,
+		column,
+	};
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation to detect conflicting `types` and `typings` fields in package.json
  * Added validation recommending `types` over `typings` in package.json

* **Documentation**
  * Updated README with TypeScript guidance on preferring `types` over `typings` and ensuring only one of those fields is set
<!-- end of auto-generated comment: release notes by coderabbit.ai -->