### PR TITLE
fix: `shadowed-types` now handles nested conditions

### DIFF
--- a/src/rules/shadowed-types.spec.ts
+++ b/src/rules/shadowed-types.spec.ts
@@ -3,12 +3,92 @@
 import { type DocumentNode, parse } from "@humanwhocodes/momoa";
 import { type PackageJson } from "../types";
 import { codeframe } from "../utils/codeframe";
-import { shadowedTypes } from "./shadowed-types";
+import { getTypesConditions, shadowedTypes } from "./shadowed-types";
 
 function generateAst(pkg: PackageJson): { content: string; ast: DocumentNode } {
 	const content = JSON.stringify(pkg, null, 2);
 	return { content, ast: parse(content) };
 }
+
+describe("getTypesConditions()", () => {
+	it("should return [] for simple string", () => {
+		expect.assertions(1);
+		const exports = "./foo.js";
+		expect(getTypesConditions(exports)).toEqual([]);
+	});
+
+	it("should return [] for path without conditions", () => {
+		expect.assertions(1);
+		const exports = {
+			".": "./foo.js",
+		};
+		expect(getTypesConditions(exports)).toEqual([]);
+	});
+
+	it("should return [] for conditions without types", () => {
+		expect.assertions(1);
+		const exports = {
+			".": {
+				default: "./foo.js",
+			},
+		};
+		expect(getTypesConditions(exports)).toEqual([]);
+	});
+
+	it("should return type paths for conditions with types", () => {
+		expect.assertions(1);
+		const exports = {
+			".": {
+				types: "./foo.d.ts",
+				default: "./foo.js",
+			},
+		};
+		expect(getTypesConditions(exports)).toEqual(["./foo.d.ts"]);
+	});
+
+	it("should return type paths for nested conditions with types", () => {
+		expect.assertions(1);
+		const exports = {
+			".": {
+				browser: {
+					types: "./browser.d.ts",
+					default: "./browser.js",
+				},
+				default: {
+					types: "./nodejs.d.ts",
+					default: "./nodejs.js",
+				},
+			},
+		};
+		expect(getTypesConditions(exports)).toEqual(["./browser.d.ts", "./nodejs.d.ts"]);
+	});
+
+	it("should return type paths for condition without path", () => {
+		expect.assertions(1);
+		const exports = {
+			types: "./foo.d.ts",
+			default: "./foo.js",
+		};
+		expect(getTypesConditions(exports)).toEqual(["./foo.d.ts"]);
+	});
+
+	it("should handle null", () => {
+		expect.assertions(1);
+		const exports = null;
+		expect(getTypesConditions(exports)).toEqual([]);
+	});
+
+	it("should not include subpaths other than .", () => {
+		expect.assertions(1);
+		const exports = {
+			"./foo": {
+				types: "./foo.d.ts",
+				default: "./foo.js",
+			},
+		};
+		expect(getTypesConditions(exports)).toEqual([]);
+	});
+});
 
 describe.each(["types", "typings"])("%s", (field) => {
 	it(`should not allow ${field} field to be shadowed by exports with types condition`, () => {
@@ -55,6 +135,34 @@ describe.each(["types", "typings"])("%s", (field) => {
 			>  9 |   "${field}": "./foo.d.ts"
 			     |   ^
 			  10 | }"
+		`);
+	});
+
+	it(`should not allow ${field} field to be shadowed by nested exports without types condition`, () => {
+		expect.assertions(1);
+		const pkg: PackageJson = {
+			name: "mock-package",
+			version: "1.2.3",
+			exports: {
+				".": {
+					browser: {
+						default: "./dist/browser.js",
+					},
+					node: {
+						default: "./dist/nodejs.js",
+					},
+				},
+			},
+			[field]: "./foo.d.ts",
+		};
+		const { content, ast } = generateAst(pkg);
+		expect(codeframe(content, shadowedTypes(pkg, ast))).toMatchInlineSnapshot(`
+			"ERROR: "${field}" cannot be resolved when respecting "exports" field (shadowed-types) at package.json
+			  12 |     }
+			  13 |   },
+			> 14 |   "${field}": "./foo.d.ts"
+			     |   ^
+			  15 | }"
 		`);
 	});
 
@@ -109,6 +217,29 @@ describe.each(["types", "typings"])("%s", (field) => {
 				},
 			},
 			[field]: "./dist/foo.d.ts",
+		};
+		const { content, ast } = generateAst(pkg);
+		expect(codeframe(content, shadowedTypes(pkg, ast))).toMatchInlineSnapshot(`""`);
+	});
+
+	it(`should allow ${field} field when one or more nested types condition exists`, () => {
+		expect.assertions(1);
+		const pkg: PackageJson = {
+			name: "mock-package",
+			version: "1.2.3",
+			exports: {
+				".": {
+					browser: {
+						types: "./dist/browser.d.ts",
+						default: "./dist/browser.js",
+					},
+					node: {
+						types: "./dist/nodejs.d.ts",
+						default: "./dist/nodejs.js",
+					},
+				},
+			},
+			[field]: "./dist/nodejs.d.ts",
 		};
 		const { content, ast } = generateAst(pkg);
 		expect(codeframe(content, shadowedTypes(pkg, ast))).toMatchInlineSnapshot(`""`);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Comprehensive test suite expansion covering edge cases in package.json export validation, including nested conditions and type field shadowing detection scenarios.

* **Refactor**
  * Improved validation logic to more accurately process and validate type field configurations within package.json exports, with enhanced handling of nested conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->